### PR TITLE
Added hostname templatization for principal to authenticate

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -27,6 +27,12 @@ options:
       Local user to perform domain join under, defaults to ubuntu.
   principal:
     type: string
-    default: host
+    default: host/{hostname}
     description: |
       principal to use when adding the server, e.g. "host/HOSTNAME.example.com"
+      This variable is templated.  You can use the following variable substitutions
+      {hostname} - the output of 'hostname -f' with no additional casing
+      {fqdn} - lower-cased FQDN of the node
+      {FQDN} - upper-cased FQDN of the node
+      {short} - lower-cased short name of the node
+      {SHORT} - upper-cased short name of the node

--- a/src/reactive/kerberos_keytab.py
+++ b/src/reactive/kerberos_keytab.py
@@ -36,3 +36,4 @@ def keytab_update_requested():
     if check_keytab_for_upgrade_needed():
         if update_keytab():
             clear_flag('kerberos.keytab-update-requested')
+            status_set('active', 'Ready')

--- a/src/templates/krb5.conf
+++ b/src/templates/krb5.conf
@@ -16,5 +16,5 @@
     }
 
 [domain_realm]
-    .{{ default_realm_lower }} = {{ default_realm }}
-    {{ default_realm_lower }} = {{ default_realm }}
+    .{{ default_domain }} = {{ default_realm }}
+    {{ default_domain }} = {{ default_realm }}


### PR DESCRIPTION
Some sites require kerberos authentication, some sites require AD authentication, all of these have different naming of principals around hostnames.  This patch attempts to provide options for admins to configure this to their liking.